### PR TITLE
[build] project: Configure CI using Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request: # run on PRs targeting any branch
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm --prefix functions ci
+    - run: npm run build:functions
+    - run: npm --prefix admin ci
+    - run: npm run build:admin
+    - run: npm test --if-present


### PR DESCRIPTION
> !! These changes were made outside the assessment period.

# Description

Add CI to build implementations before merging to master. This way we have more confidence the new code won't break the master. Later we could configure a deploy when merging code into master.

- The CI builds the branchs from all PRs
- The CI will build the main branch on new commits

Base branch is from [this PR - [build] admin/functions: Setup Project Linter](https://github.com/dendriel/softg-backend-assignment/pull/2)