### PR TITLE
[feat] Add paginated table

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -9,6 +9,7 @@
     "dev": "vite --force",
     "test": "vitest run --coverage",
     "build": "tsc && vite build",
+    "build:watch": "npx vite build --watch",
     "lint": "eslint . --ext .ts,.tsx",
     "preview": "vite preview",
     "hardUpdate": "npx -y rimraf node_modules/ package-lock.json ; npm i"

--- a/admin/src/components/GameTable.tsx
+++ b/admin/src/components/GameTable.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Table,
   Button,
   Space,
   Popconfirm,
+  type TablePaginationConfig,
 } from 'antd';
 import { useNavigate } from 'react-router-dom';
 
@@ -16,11 +17,45 @@ export interface GameEntry {
 
 interface GameTableProps {
     data: GameEntry[];
+    total: number;
+    setCurrPage: (page: number) => void;
+    setPageSize: (size: number) => void;
     onDelete: (id: string) => void;
 }
 
-const GameTable: React.FC<GameTableProps> = ({ data, onDelete }: GameTableProps) => {
+const GameTable: React.FC<GameTableProps> = ({
+  data, total, onDelete, setCurrPage, setPageSize,
+}:
+  GameTableProps) => {
   const navigate = useNavigate();
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: 10,
+    total,
+    showSizeChanger: true,
+    showTotal: showTotalPages,
+  });
+
+  function onPaginationChanged(newPagination: TablePaginationConfig) {
+    console.log('Pagination changed:', newPagination);
+
+    const currPage = newPagination.current || 1;
+    const pageSize = newPagination.pageSize || 10;
+    setCurrPage(currPage);
+    setPageSize(pageSize);
+
+    setPagination({
+      current: currPage,
+      pageSize,
+      total,
+      showSizeChanger: true,
+      showTotal: showTotalPages,
+    });
+  }
+
+  function showTotalPages(newTotal: number, range: [number, number]) {
+    return `${range[0]}-${range[1]} of ${newTotal} games`;
+  }
 
   function handleDeleteButton(id: string) {
     return <>
@@ -55,7 +90,12 @@ const GameTable: React.FC<GameTableProps> = ({ data, onDelete }: GameTableProps)
   ];
 
   return (
-    <Table dataSource={data.map((item) => ({ ...item, key: item.id }))} columns={tableColumns} />
+    <Table
+      dataSource={data.map((item) => ({ ...item, key: item.id }))}
+      columns={tableColumns}
+      pagination={pagination}
+      onChange={onPaginationChanged}
+    />
   );
 };
 

--- a/admin/src/pages/GameList.tsx
+++ b/admin/src/pages/GameList.tsx
@@ -4,21 +4,30 @@ import GameTable, { GameEntry } from '../components/GameTable.tsx';
 
 const { Content } = Layout;
 
+type GamesPaginatedDto = {
+  data: GameEntry[];
+  total: number;
+};
+
 const GameList: React.FC = () => {
+  const [currPage, setCurrPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
   const [data, setData] = useState<GameEntry[]>([]);
+  const [totalEntries, setTotalEntries] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/v1/games')
+    fetch(`/api/v1/games?page=${currPage}&pageSize=${pageSize}`)
       .then((res) => {
         if (!res.ok) {
           throw new Error('Network response was not ok');
         }
         return res.json();
       })
-      .then((games: GameEntry[]) => {
-        setData(games);
+      .then((gamesPaginated: GamesPaginatedDto) => {
+        setData(gamesPaginated.data);
+        setTotalEntries(gamesPaginated.total);
       })
       .catch((err) => {
         console.error('Error fetching games:', err);
@@ -27,7 +36,7 @@ const GameList: React.FC = () => {
       .finally(() => {
         setLoading(false);
       });
-  }, []);
+  }, [currPage, pageSize]);
 
   const handleDelete = async (id: string) => {
     if (loading) {
@@ -50,7 +59,13 @@ const GameList: React.FC = () => {
                 ) : error ? (
                     <Alert type="error" message={error} />
                 ) : (
-                    <GameTable data={data} onDelete={handleDelete} />
+                    <GameTable
+                      data={data}
+                      total={totalEntries}
+                      setCurrPage={setCurrPage}
+                      setPageSize={setPageSize}
+                      onDelete={handleDelete}
+                      />
                 )}
             </Content>
         </>

--- a/firebase.docker.json
+++ b/firebase.docker.json
@@ -26,7 +26,7 @@
       {
         "source": "/api/**",
         "function": {
-          "functionId": "api",
+          "functionId": "admin",
           "region": "europe-west3",
           "pinTag": true
         }

--- a/firebase.json
+++ b/firebase.json
@@ -26,7 +26,7 @@
       {
         "source": "/api/**",
         "function": {
-          "functionId": "api",
+          "functionId": "admin",
           "region": "europe-west3",
           "pinTag": true
         }

--- a/functions/http-requests/create-game.rest
+++ b/functions/http-requests/create-game.rest
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:5004/demo-project/europe-west3/api/v1/games
+POST http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games
 Content-Type: application/json
 
 {

--- a/functions/http-requests/delete-game.rest
+++ b/functions/http-requests/delete-game.rest
@@ -1,1 +1,1 @@
-DELETE http://127.0.0.1:5004/demo-project/europe-west3/api/v1/games/THEugzq4lv0jYsmURMpj
+DELETE http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games/THEugzq4lv0jYsmURMpj

--- a/functions/http-requests/edit-game.rest
+++ b/functions/http-requests/edit-game.rest
@@ -1,4 +1,4 @@
-PATCH http://127.0.0.1:5004/demo-project/europe-west3/api/v1/games/fDwUO2Scvk30j7Fyncvk
+PATCH http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games/fDwUO2Scvk30j7Fyncvk
 Content-Type: application/json
 
 {

--- a/functions/http-requests/get-game.rest
+++ b/functions/http-requests/get-game.rest
@@ -1,1 +1,1 @@
-GET http://127.0.0.1:5004/demo-project/europe-west3/api/v1/games/wUBaSQvqcxbZSyQFWL8a
+GET http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games/wUBaSQvqcxbZSyQFWL8a

--- a/functions/http-requests/get-games-paginated.rest
+++ b/functions/http-requests/get-games-paginated.rest
@@ -1,0 +1,2 @@
+GET http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games?page=1&pageSize=3
+Content-Type: application/json

--- a/functions/http-requests/get-games.rest
+++ b/functions/http-requests/get-games.rest
@@ -1,2 +1,2 @@
-GET http://127.0.0.1:5004/demo-project/europe-west3/api/v1/games
+GET http://127.0.0.1:5004/demo-project/europe-west3/admin/api/v1/games
 Content-Type: application/json

--- a/functions/src/apis/games/dtos/GamesPaginatedDto.ts
+++ b/functions/src/apis/games/dtos/GamesPaginatedDto.ts
@@ -1,0 +1,6 @@
+import {Game} from '../Game';
+
+export interface GamesPaginatedDto {
+    data: Game[];
+    total: number;
+}

--- a/functions/src/apis/games/dtos/index.ts
+++ b/functions/src/apis/games/dtos/index.ts
@@ -1,2 +1,3 @@
 export * from './SaveGameDto.js';
 export * from './SaveGameResponseDto.js';
+export * from './GamesPaginatedDto.js';

--- a/functions/src/apis/games/games.ts
+++ b/functions/src/apis/games/games.ts
@@ -1,15 +1,24 @@
+import type FirebaseFirestore from 'firebase-admin/firestore';
 import {getFirestore} from '../../gateway/firestore';
 import {memoize} from '../../utils';
-import {SaveGameDto, SaveGameResponseDto} from './dtos';
+import {
+  SaveGameDto,
+  SaveGameResponseDto,
+  GamesPaginatedDto,
+} from './dtos';
 import {Game} from './';
 
 const getCollection = memoize(() =>
   getFirestore().collection('games'),
 );
 
+type FirebaseDoc = FirebaseFirestore.
+  DocumentSnapshot<FirebaseFirestore.DocumentData, FirebaseFirestore.DocumentData>;
+
 /**
  * Get all stored games.
- * WARNING: for environments with a lot of games, we should implement pagination.
+ * @deprecated This function is deprecated due to potential performance issues with large datasets.
+ * It is recommended to use `getGamesPaginated` for better performance.
  * @return {Promise<Game[]>} A promise that resolves to an array of Game objects.
  */
 export async function getGames(): Promise<Game[]> {
@@ -22,6 +31,42 @@ export async function getGames(): Promise<Game[]> {
       id: doc.id,
     };
   }) as Game[];
+}
+
+/**
+ * Get games with pagination.
+ * @param {number} page target page number (1-based index).
+ * @param {number} pageSize number of items per page.
+ * @return {GamesPaginatedDto} the paginated games alongside the total number of games.
+ */
+export async function getGamesPaginated(page: number, pageSize: number):
+  Promise<GamesPaginatedDto> {
+  const collection = getCollection();
+
+  const startEntry = (page - 1) * pageSize;
+  const result = await collection
+    .orderBy('name', 'asc')
+    .offset(startEntry)
+    .limit(pageSize)
+    .get();
+
+  const games = result.docs.map(mapGameData) as Game[];
+
+  const totalGamesDoc = await collection.count().get();
+  const totalGames = totalGamesDoc.data()?.count || 0;
+
+  return {
+    'data': games,
+    'total': totalGames,
+  };
+}
+
+function mapGameData(doc: FirebaseDoc): Game {
+  const data = doc.data();
+  return {
+    ...data,
+    id: doc.id,
+  } as Game;
 }
 
 /**

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,7 @@
 import {https} from 'firebase-functions/v2';
 import {app} from './app.js';
 
-export const api = https.onRequest(
+export const admin = https.onRequest(
   {
     region: 'europe-west3',
     minInstances: 0,

--- a/functions/src/routes/v1/games/index.ts
+++ b/functions/src/routes/v1/games/index.ts
@@ -1,14 +1,34 @@
 import {wrapAsync, createRouter} from '../../../utils';
-import {getGames, addGame, deleteGame, getGame, editGame, Game} from '../../../apis/games';
+import {
+  getGames,
+  getGamesPaginated,
+  addGame,
+  deleteGame,
+  getGame,
+  editGame,
+  Game,
+} from '../../../apis/games';
 import {newApiError} from '../../../utils';
 
 export const gamesRouter = createRouter();
 
 gamesRouter.get(
   '/',
-  wrapAsync(() => {
+  wrapAsync(async (req) => {
+    const {page, pageSize} = req.query;
+    const pageNumber = parseInt(page as string, 10);
+    const pageSizeNumber = parseInt(pageSize as string, 10);
+    if (isNaN(pageNumber) || isNaN(pageSizeNumber)) {
+      throw newApiError('Invalid page/pageSize parameters', 400);
+    }
+
     try {
-      return getGames();
+      if (page && pageSize) {
+        return getGamesPaginated(pageNumber, pageSizeNumber);
+      } else {
+        // DEPRECATED: Non-paginated API call
+        return getGames();
+      }
     } catch (error: unknown) {
       throw newApiError('Error while fetching games', error, 500);
     }

--- a/games.json
+++ b/games.json
@@ -348,5 +348,479 @@
         "baseGame": "26",
         "standalone": false,
         "type": "Expansion"
+    },
+    {
+        "id": "28",
+        "name": "Terraforming Mars",
+        "releaseYear": 2016,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Stronghold Games",
+        "expansions": [
+            "29"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "29",
+        "name": "Terraforming Mars: Prelude",
+        "releaseYear": 2018,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Stronghold Games",
+        "baseGame": "28",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "30",
+        "name": "Brass: Birmingham",
+        "releaseYear": 2018,
+        "players": {
+            "min": 2,
+            "max": 4
+        },
+        "publisher": "Roxley Games",
+        "type": "BaseGame"
+    },
+    {
+        "id": "31",
+        "name": "Gaia Project",
+        "releaseYear": 2017,
+        "players": {
+            "min": 1,
+            "max": 4
+        },
+        "publisher": "Z-Man Games",
+        "type": "BaseGame"
+    },
+    {
+        "id": "32",
+        "name": "Great Western Trail",
+        "releaseYear": 2016,
+        "players": {
+            "min": 2,
+            "max": 4
+        },
+        "publisher": "Stronghold Games",
+        "expansions": [
+            "33"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "33",
+        "name": "Great Western Trail: Rails to the North",
+        "releaseYear": 2018,
+        "players": {
+            "min": 2,
+            "max": 4
+        },
+        "publisher": "Stronghold Games",
+        "baseGame": "32",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "34",
+        "name": "Power Grid",
+        "releaseYear": 2004,
+        "players": {
+            "min": 2,
+            "max": 6
+        },
+        "publisher": "Rio Grande Games",
+        "expansions": [
+            "35"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "35",
+        "name": "Power Grid: Factory Manager",
+        "releaseYear": 2009,
+        "players": {
+            "min": 2,
+            "max": 5
+        },
+        "publisher": "Rio Grande Games",
+        "baseGame": "34",
+        "standalone": true,
+        "type": "Expansion"
+    },
+    {
+        "id": "36",
+        "name": "Agricola",
+        "releaseYear": 2007,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Lookout Games",
+        "expansions": [
+            "37"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "37",
+        "name": "Agricola: Farmers of the Moor",
+        "releaseYear": 2009,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Lookout Games",
+        "baseGame": "36",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "38",
+        "name": "Puerto Rico",
+        "releaseYear": 2002,
+        "players": {
+            "min": 3,
+            "max": 5
+        },
+        "publisher": "Ravensburger",
+        "type": "BaseGame"
+    },
+    {
+        "id": "39",
+        "name": "Concordia",
+        "releaseYear": 2013,
+        "players": {
+            "min": 2,
+            "max": 5
+        },
+        "publisher": "PD-Verlag",
+        "expansions": [
+            "40"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "40",
+        "name": "Concordia: Salsa",
+        "releaseYear": 2014,
+        "players": {
+            "min": 2,
+            "max": 6
+        },
+        "publisher": "PD-Verlag",
+        "baseGame": "39",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "41",
+        "name": "Splendor",
+        "releaseYear": 2014,
+        "players": {
+            "min": 2,
+            "max": 4
+        },
+        "publisher": "Space Cowboys",
+        "type": "BaseGame"
+    },
+    {
+        "id": "42",
+        "name": "King of Tokyo",
+        "releaseYear": 2011,
+        "players": {
+            "min": 2,
+            "max": 6
+        },
+        "publisher": "Iello",
+        "expansions": [
+            "43"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "43",
+        "name": "King of Tokyo: Power Up!",
+        "releaseYear": 2012,
+        "players": {
+            "min": 2,
+            "max": 6
+        },
+        "publisher": "Iello",
+        "baseGame": "42",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "44",
+        "name": "Mansions of Madness",
+        "releaseYear": 2011,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Fantasy Flight Games",
+        "expansions": [
+            "45"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "45",
+        "name": "Mansions of Madness: Forbidden Alchemy",
+        "releaseYear": 2011,
+        "players": {
+            "min": 1,
+            "max": 5
+        },
+        "publisher": "Fantasy Flight Games",
+        "baseGame": "44",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "46",
+        "name": "Eclipse",
+        "releaseYear": 2011,
+        "players": {
+            "min": 2,
+            "max": 6
+        },
+        "publisher": "Lautapelit.fi",
+        "expansions": [
+            "47"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "47",
+        "name": "Eclipse: Rise of the Ancients",
+        "releaseYear": 2012,
+        "players": {
+            "min": 2,
+            "max": 9
+        },
+        "publisher": "Lautapelit.fi",
+        "baseGame": "46",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "48",
+        "name": "Arkham Horror",
+        "releaseYear": 2005,
+        "players": {
+            "min": 1,
+            "max": 8
+        },
+        "publisher": "Fantasy Flight Games",
+        "expansions": [
+            "49"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "49",
+        "name": "Arkham Horror: Dunwich Horror",
+        "releaseYear": 2006,
+        "players": {
+            "min": 1,
+            "max": 8
+        },
+        "publisher": "Fantasy Flight Games",
+        "baseGame": "48",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "50",
+        "name": "Everdell",
+        "releaseYear": 2018,
+        "players": {
+            "min": 1,
+            "max": 4
+        },
+        "publisher": "Starling Games",
+        "expansions": [
+            "51"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "51",
+        "name": "Everdell: Pearlbrook",
+        "releaseYear": 2019,
+        "players": {
+            "min": 1,
+            "max": 4
+        },
+        "publisher": "Starling Games",
+        "baseGame": "50",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "52",
+        "name": "Robinson Crusoe",
+        "releaseYear": 2012,
+        "players": {
+            "min": 1,
+            "max": 4
+        },
+        "publisher": "Portal Games",
+        "expansions": [
+            "53"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "53",
+        "name": "Robinson Crusoe: Voyage of the Beagle",
+        "releaseYear": 2013,
+        "players": {
+            "min": 1,
+            "max": 4
+        },
+        "publisher": "Portal Games",
+        "baseGame": "52",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "54",
+        "name": "Machi Koro",
+        "releaseYear": 2012,
+        "players": {
+            "min": 2,
+            "max": 4
+        },
+        "publisher": "IDW Games",
+        "expansions": [
+            "55"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "55",
+        "name": "Machi Koro: Harbor Expansion",
+        "releaseYear": 2013,
+        "players": {
+            "min": 2,
+            "max": 5
+        },
+        "publisher": "IDW Games",
+        "baseGame": "54",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "56",
+        "name": "Dead of Winter",
+        "releaseYear": 2014,
+        "players": {
+            "min": 2,
+            "max": 5
+        },
+        "publisher": "Plaid Hat Games",
+        "expansions": [
+            "57"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "57",
+        "name": "Dead of Winter: The Long Night",
+        "releaseYear": 2016,
+        "players": {
+            "min": 2,
+            "max": 11
+        },
+        "publisher": "Plaid Hat Games",
+        "baseGame": "56",
+        "standalone": true,
+        "type": "Expansion"
+    },
+    {
+        "id": "58",
+        "name": "Viticulture",
+        "releaseYear": 2013,
+        "players": {
+            "min": 1,
+            "max": 6
+        },
+        "publisher": "Stonemaier Games",
+        "expansions": [
+            "59"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "59",
+        "name": "Viticulture: Tuscany",
+        "releaseYear": 2014,
+        "players": {
+            "min": 1,
+            "max": 6
+        },
+        "publisher": "Stonemaier Games",
+        "baseGame": "58",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "60",
+        "name": "Betrayal at House on the Hill",
+        "releaseYear": 2004,
+        "players": {
+            "min": 3,
+            "max": 6
+        },
+        "publisher": "Avalon Hill",
+        "type": "BaseGame"
+    },
+    {
+        "id": "61",
+        "name": "Eldritch Horror",
+        "releaseYear": 2013,
+        "players": {
+            "min": 1,
+            "max": 8
+        },
+        "publisher": "Fantasy Flight Games",
+        "expansions": [
+            "62"
+        ],
+        "type": "BaseGame"
+    },
+    {
+        "id": "62",
+        "name": "Eldritch Horror: Forsaken Lore",
+        "releaseYear": 2014,
+        "players": {
+            "min": 1,
+            "max": 8
+        },
+        "publisher": "Fantasy Flight Games",
+        "baseGame": "61",
+        "standalone": false,
+        "type": "Expansion"
+    },
+    {
+        "id": "63",
+        "name": "Lords of Waterdeep",
+        "releaseYear": 2012,
+        "players": {
+            "min": 2,
+            "max": 5
+        },
+        "publisher": "Wizards of the Coast",
+        "expansions": [
+            "64"
+        ],
+        "type": "BaseGame"
     }
 ]


### PR DESCRIPTION
> !! These changes were made outside the assessment period.

# Description

Updategames listing page to use pagination. Now it will fetch data on demand.

## Changes

[feat] admin: Update games list to use pagination

- Fetch data on demand
  - We could cache data so it will be more efficient to avoid fetching games already there. But it will make the implementation more complex as we will also have to define an eviction mechanism
- Add build:watch command so we can hot reload admin changes while running everything on firebase emulator
- Add more samples to games.json

[feat] functions: Add paginated games get endpoint

- Add getGamesPaginated to enable paginated listing of games
  - It can be called at /api/v1/games with page and pageSize query params
- Add sample API call in http-requests for getGamesPaginated function
- Deprecate previous dangerous non-paginated getGames function which would fetch every game from DB
- Renamed cloud function name from `api` to `admin` to be less confuse (we will write admin/api instead of api/api)
  - Also update http-request samples to follow the new path